### PR TITLE
JOURNAL_IMAGE_GITHUB_YEARLY

### DIFF
--- a/JOURNAL_IMAGE_GITHUB_YEARLY
+++ b/JOURNAL_IMAGE_GITHUB_YEARLY
@@ -1,0 +1,1 @@
+Branching off to create a yearly GitHub Git-image repository, so less time can be spent setting it up.


### PR DESCRIPTION
Branching off to create a yearly GitHub Git-image repository, so less time can be spent setting it up.